### PR TITLE
Add CLI entry point to project

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,6 +7,7 @@ name = "pypi"
 numpy = "1.23.4"
 scikit-image = "0.19.3"
 pylettize = {editable = true, path = "."}
+docopt = "*"
 
 [dev-packages]
 black = "22.10.0"

--- a/Pipfile
+++ b/Pipfile
@@ -7,7 +7,7 @@ name = "pypi"
 numpy = "1.23.4"
 scikit-image = "0.19.3"
 pylettize = {editable = true, path = "."}
-docopt = "*"
+docopt = "0.6.2"
 
 [dev-packages]
 black = "22.10.0"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "abfec594047b3d1bb9530253f3afdb04e957402a391bef82d8e80eed3cdfdfc5"
+            "sha256": "fe2794e3ed83c02822dc8010cc229a980e33bee6b373ad3772de847ed473f611"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -84,6 +84,13 @@
             "markers": "python_version >= '3.7'",
             "version": "==6.5.0"
         },
+        "docopt": {
+            "hashes": [
+                "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491"
+            ],
+            "index": "pypi",
+            "version": "==0.6.2"
+        },
         "exceptiongroup": {
             "hashes": [
                 "sha256:2ac84b496be68464a2da60da518af3785fff8b7ec0d090a581604bc870bdee41",
@@ -94,11 +101,11 @@
         },
         "imageio": {
             "hashes": [
-                "sha256:63f007b7f2a082306e36922b3fd529a7aa305d2b78f46195bab8e22bbfe866e9",
-                "sha256:a4b88f9f3d428b8c0ceeb7e297df8c346a642bb7e3111743eb85717d60b26f6f"
+                "sha256:0fae027addf02bc89c73a56cc157ad84557f8b8b84aa19b4cb706fefca2d88ff",
+                "sha256:bb173f8af27e4921f59539c4d45068fcedb892e58261fce8253f31c9a0ff9ccf"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.22.3"
+            "version": "==2.22.4"
         },
         "iniconfig": {
             "hashes": [
@@ -172,6 +179,7 @@
                 "sha256:2e0918e03aa0c72ea56edbb00d4d664294815aa11291a11504a377ea018330d3",
                 "sha256:3033fbe1feb1b59394615a1cafaee85e49d01b51d54de0cbf6aa8e64182518a1",
                 "sha256:3168434d303babf495d4ba58fc22d6604f6e2afb97adc6a423e917dab828939c",
+                "sha256:32a44128c4bdca7f31de5be641187367fe2a450ad83b833ef78910397db491aa",
                 "sha256:3dd6caf940756101205dffc5367babf288a30043d35f80936f9bfb37f8355b32",
                 "sha256:40e1ce476a7804b0fb74bcfa80b0a2206ea6a882938eaba917f7a0f004b42502",
                 "sha256:41e0051336807468be450d52b8edd12ac60bebaa97fe10c8b660f116e50b30e4",
@@ -216,6 +224,7 @@
                 "sha256:c7025dce65566eb6e89f56c9509d4f628fddcedb131d9465cacd3d8bac337e7e",
                 "sha256:c935a22a557a560108d780f9a0fc426dd7459940dc54faa49d83249c8d3e760f",
                 "sha256:dbb8e7f2abee51cef77673be97760abff1674ed32847ce04b4af90f610144c7b",
+                "sha256:e6ea6b856a74d560d9326c0f5895ef8050126acfdc7ca08ad703eb0081e82b74",
                 "sha256:ebf2029c1f464c59b8bdbe5143c79fa2045a581ac53679733d3a91d400ff9efb",
                 "sha256:f1ff2ee69f10f13a9596480335f406dd1f70c3650349e2be67ca3139280cade0"
             ],
@@ -579,33 +588,39 @@
         },
         "mypy": {
             "hashes": [
-                "sha256:1021c241e8b6e1ca5a47e4d52601274ac078a89845cfde66c6d5f769819ffa1d",
-                "sha256:14d53cdd4cf93765aa747a7399f0961a365bcddf7855d9cef6306fa41de01c24",
-                "sha256:175f292f649a3af7082fe36620369ffc4661a71005aa9f8297ea473df5772046",
-                "sha256:26ae64555d480ad4b32a267d10cab7aec92ff44de35a7cd95b2b7cb8e64ebe3e",
-                "sha256:41fd1cf9bc0e1c19b9af13a6580ccb66c381a5ee2cf63ee5ebab747a4badeba3",
-                "sha256:5085e6f442003fa915aeb0a46d4da58128da69325d8213b4b35cc7054090aed5",
-                "sha256:58f27ebafe726a8e5ccb58d896451dd9a662a511a3188ff6a8a6a919142ecc20",
-                "sha256:6389af3e204975d6658de4fb8ac16f58c14e1bacc6142fee86d1b5b26aa52bda",
-                "sha256:724d36be56444f569c20a629d1d4ee0cb0ad666078d59bb84f8f887952511ca1",
-                "sha256:75838c649290d83a2b83a88288c1eb60fe7a05b36d46cbea9d22efc790002146",
-                "sha256:7b35ce03a289480d6544aac85fa3674f493f323d80ea7226410ed065cd46f206",
-                "sha256:85f7a343542dc8b1ed0a888cdd34dca56462654ef23aa673907305b260b3d746",
-                "sha256:86ebe67adf4d021b28c3f547da6aa2cce660b57f0432617af2cca932d4d378a6",
-                "sha256:8ee8c2472e96beb1045e9081de8e92f295b89ac10c4109afdf3a23ad6e644f3e",
-                "sha256:91781eff1f3f2607519c8b0e8518aad8498af1419e8442d5d0afb108059881fc",
-                "sha256:a692a8e7d07abe5f4b2dd32d731812a0175626a90a223d4b58f10f458747dd8a",
-                "sha256:a705a93670c8b74769496280d2fe6cd59961506c64f329bb179970ff1d24f9f8",
-                "sha256:c6e564f035d25c99fd2b863e13049744d96bd1947e3d3d2f16f5828864506763",
-                "sha256:cebca7fd333f90b61b3ef7f217ff75ce2e287482206ef4a8b18f32b49927b1a2",
-                "sha256:d6af646bd46f10d53834a8e8983e130e47d8ab2d4b7a97363e35b24e1d588947",
-                "sha256:e7aeaa763c7ab86d5b66ff27f68493d672e44c8099af636d433a7f3fa5596d40",
-                "sha256:eaa97b9ddd1dd9901a22a879491dbb951b5dec75c3b90032e2baa7336777363b",
-                "sha256:eb7a068e503be3543c4bd329c994103874fa543c1727ba5288393c21d912d795",
-                "sha256:f793e3dd95e166b66d50e7b63e69e58e88643d80a3dcc3bcd81368e0478b089c"
+                "sha256:0680389c34284287fe00e82fc8bccdea9aff318f7e7d55b90d967a13a9606013",
+                "sha256:1767830da2d1afa4e62b684647af0ff79b401f004d7fa08bc5b0ce2d45bcd5ec",
+                "sha256:1ee5f99817ee70254e7eb5cf97c1b11dda29c6893d846c8b07bce449184e9466",
+                "sha256:262c543ef24deb10470a3c1c254bb986714e2b6b1a67d66daf836a548a9f316c",
+                "sha256:269f0dfb6463b8780333310ff4b5134425157ef0d2b1d614015adaf6d6a7eabd",
+                "sha256:2a3150d409609a775c8cb65dbe305c4edd7fe576c22ea79d77d1454acd9aeda8",
+                "sha256:2b6f85c2ad378e3224e017904a051b26660087b3b76490d533b7344f1546d3ff",
+                "sha256:3227f14fe943524f5794679156488f18bf8d34bfecd4623cf76bc55958d229c5",
+                "sha256:3ff201a0c6d3ea029d73b1648943387d75aa052491365b101f6edd5570d018ea",
+                "sha256:46897755f944176fbc504178422a5a2875bbf3f7436727374724842c0987b5af",
+                "sha256:47a9955214615108c3480a500cfda8513a0b1cd3c09a1ed42764ca0dd7b931dd",
+                "sha256:49082382f571c3186ce9ea0bd627cb1345d4da8d44a8377870f4442401f0a706",
+                "sha256:4a8a6c10f4c63fbf6ad6c03eba22c9331b3946a4cec97f008e9ffb4d3b31e8e2",
+                "sha256:6826d9c4d85bbf6d68cb279b561de6a4d8d778ca8e9ab2d00ee768ab501a9852",
+                "sha256:72382cb609142dba3f04140d016c94b4092bc7b4d98ca718740dc989e5271b8d",
+                "sha256:7da0005e47975287a92b43276e460ac1831af3d23032c34e67d003388a0ce8d0",
+                "sha256:8798c8ed83aa809f053abff08664bdca056038f5a02af3660de00b7290b64c47",
+                "sha256:8f1940325a8ed460ba03d19ab83742260fa9534804c317224e5d4e5aa588e2d6",
+                "sha256:8f694d6d09a460b117dccb6857dda269188e3437c880d7b60fa0014fa872d1e9",
+                "sha256:9b8f4a8213b1fd4b751e26b59ae0e0c12896568d7e805861035c7a15ed6dc9eb",
+                "sha256:9d851c09b981a65d9d283a8ccb5b1d0b698e580493416a10942ef1a04b19fd37",
+                "sha256:aaf1be63e0207d7d17be942dcf9a6b641745581fe6c64df9a38deb562a7dbafa",
+                "sha256:aba38e3dd66bdbafbbfe9c6e79637841928ea4c79b32e334099463c17b0d90ef",
+                "sha256:b08541a06eed35b543ae1a6b301590eb61826a1eb099417676ddc5a42aa151c5",
+                "sha256:be88d665e76b452c26fb2bdc3d54555c01226fba062b004ede780b190a50f9db",
+                "sha256:c76c769c46a1e6062a84837badcb2a7b0cdb153d68601a61f60739c37d41cc74",
+                "sha256:cc6019808580565040cd2a561b593d7c3c646badd7e580e07d875eb1bf35c695",
+                "sha256:cd2dd3730ba894ec2a2082cc703fbf3e95a08479f7be84912e3131fc68809d46",
+                "sha256:d555aa7f44cecb7ea3c0ac69d58b1a5afb92caa017285a8e9c4efbf0518b61b4",
+                "sha256:d847dd23540e2912d9667602271e5ebf25e5788e7da46da5ffd98e7872616e8e"
             ],
             "index": "pypi",
-            "version": "==0.982"
+            "version": "==0.990"
         },
         "mypy-extensions": {
             "hashes": [
@@ -640,11 +655,11 @@
         },
         "platformdirs": {
             "hashes": [
-                "sha256:027d8e83a2d7de06bbac4e5ef7e023c02b863d7ea5d079477e722bb41ab25788",
-                "sha256:58c8abb07dcb441e6ee4b11d8df0ac856038f944ab98b7be6b27b2a3c7feef19"
+                "sha256:0cb405749187a194f444c25c82ef7225232f11564721eabffc6ec70df83b11cb",
+                "sha256:6e52c21afff35cb659c6e52d8b4d61b9bd544557180440538f255d9382c8cbe0"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.5.2"
+            "version": "==2.5.3"
         },
         "pluggy": {
             "hashes": [
@@ -766,11 +781,11 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:512e5536220e38146176efb833d4a62aa726b7bbff82cfbc8ba9eaa3996e0b17",
-                "sha256:f62ea9da9ed6289bfe868cd6845968a2c854d1427f8548d52cae02a42b4f0356"
+                "sha256:d0b9a8433464d5800cbe05094acf5c6d52a91bfac9b52bcfc4d41382be5d5d31",
+                "sha256:e197a19aa8ec9722928f2206f8de752def0e4c9fc6953527360d1c36d94ddb2f"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==65.5.0"
+            "version": "==65.5.1"
         },
         "six": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "fe2794e3ed83c02822dc8010cc229a980e33bee6b373ad3772de847ed473f611"
+            "sha256": "633949d233e77b218c940872a759de0e8ea2f3fc50c97f6cc3b981bab3037d41"
         },
         "pipfile-spec": 6,
         "requires": {

--- a/pylettize/__init__.py
+++ b/pylettize/__init__.py
@@ -1,5 +1,6 @@
 """Pylettize package."""
 
-from .pylettize import main
+from . import cli as cli
+from . import pylettize as core
 
-__all__ = ["main"]
+__all__ = ["core", "cli"]

--- a/pylettize/cli.py
+++ b/pylettize/cli.py
@@ -26,16 +26,16 @@ Usage:
 """
 
 import sys
-from importlib import resources
+from pathlib import Path
 from typing import Any, Dict, List
 
 import numpy as np
 import skimage.io as imio
 from docopt import docopt
 
+from pylettize.palettes import get_default_palette, get_palette_from_file
 from pylettize.pylettize import (
     hard_blending,
-    hex_to_rgb,
     linear_blending,
     similarity_map,
     weight_map,
@@ -51,12 +51,11 @@ def run(argv: List[str]):
 
     # Get palette
     if args["--palette-file"]:
-        raise NotImplementedError("Custom palette files not supported yet")
+        palette_file = Path(args["<palette>"])
+        assert palette_file.exists(), f"Could not find palette file '{palette_file}'"
+        palette = get_palette_from_file(palette_file)
     else:
-        palette_file = resources.open_text("pylettize.palettes", args["<palette>"])
-
-    with palette_file as file:
-        palette = list(map(hex_to_rgb, file))
+        palette = get_default_palette(args["<palette>"])
 
     # Do the blending
     if args["hard"]:

--- a/pylettize/cli.py
+++ b/pylettize/cli.py
@@ -25,9 +25,8 @@ Usage:
 -T <temperature>, --temperature=<temperature>  Blending temperature [default: 0.5]
 """
 
-import sys
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict
 
 import numpy as np
 import skimage.io as imio
@@ -42,9 +41,9 @@ from pylettize.pylettize import (
 )
 
 
-def run(argv: List[str]):
+def run() -> None:
     """Run the pylettize CLI with a given list of argument values."""
-    args: Dict[str, Any] = docopt(str(__doc__), argv)
+    args: Dict[str, Any] = docopt(str(__doc__))
 
     # Get the input image
     input_img = imio.imread(args["<img>"]) / 255.0
@@ -80,10 +79,5 @@ def run(argv: List[str]):
     imio.imsave(args["--output"], output_img)
 
 
-def _console_entry_point():
-    """Invoke the CLI externally."""
-    run(sys.argv[1:])
-
-
 if __name__ == "__main__":
-    _console_entry_point()
+    run()

--- a/pylettize/cli.py
+++ b/pylettize/cli.py
@@ -1,0 +1,96 @@
+"""
+Pylettize. Image re-palettizer written in Python.
+
+Palettes:
+    Any text file with line-separated hex-colors can be supplied as the palette.
+    In addition, the following named default palettes are available
+    * gruvbox    The classic Gruvbox color scheme
+    * obama      Colors from the "Hope" posters
+    * primaries  RGB and CMY
+
+Blending strategies:
+    Pylettize provides two main blending strategies
+    * hard  Using a binary mapping from input pixel color to palette color
+    * soft  Using a linear combination of palette colors in each pixel
+            The degree of "softness" is determined with the -T temperature option
+
+Usage:
+    pylettize -h
+    pylettize hard <img> [-p] <palette> [-o <output>]
+    pylettize soft <img> [-p] <palette> [-o <output> -T <temperature>]
+
+-h, --help                                     Show this screen
+-p, --palette-file                             Use a provided text file as palette
+-o <output>, --output=<output>                 Output file [default: pylettized.png]
+-T <temperature>, --temperature=<temperature>  Blending temperature [default: 0.5]
+"""
+
+import sys
+from importlib import resources
+from typing import Any, Dict, List
+
+import numpy as np
+import skimage.io as imio
+from docopt import docopt
+
+from pylettize.pylettize import (
+    dist_to_color,
+    hard_blending,
+    hex_to_rgb,
+    linear_blending,
+)
+
+
+def run(argv: List[str]):
+    """Run the pylettize CLI with a given list of argument values."""
+    args: Dict[str, Any] = docopt(str(__doc__), argv)
+
+    # Get the input image
+    input_img = imio.imread(args["<img>"]) / 255.0
+
+    # Get palette
+    if args["--palette-file"]:
+        raise NotImplementedError("Custom palette files not supported yet")
+    else:
+        palette_file = resources.open_text("pylettize.palettes", args["<palette>"])
+
+    with palette_file as file:
+        palette = np.array(list(map(hex_to_rgb, file)))
+
+    # Compute the distance map and corresponding palette lookup
+    dist_map = np.stack([dist_to_color(input_img, color) for color in palette])
+
+    # Do the blending
+    if args["hard"]:
+        mapped_im = hard_blending(dist_map, palette)
+    elif args["soft"]:
+        # Apply temperature scaled softmax
+        temp: float = float(args["--temperature"])
+        weight_map = np.exp((1.0 - dist_map) / temp)
+        weight_map /= np.sum(weight_map, axis=0)
+        mapped_im = linear_blending(weight_map, palette)
+    else:
+        raise AssertionError(
+            """
+            Could not resolve the blending strategy.
+            You have stumbled upon a bug! Feel free to report it at
+            https://github.com/frans-johansson/pylettize/issues.
+            """
+        )
+
+    # Save output image
+    output_img = (mapped_im * 255).astype(np.uint8)
+    imio.imsave(args["--output"], output_img)
+
+    # Debugging
+    # for i, im in enumerate(dist_map):
+    #     imio.imsave(f"dist_map_{i}.png", im)
+
+
+def _console_entry_point():
+    """Invoke the CLI externally."""
+    run(sys.argv[1:])
+
+
+if __name__ == "__main__":
+    _console_entry_point()

--- a/pylettize/palettes/__init__.py
+++ b/pylettize/palettes/__init__.py
@@ -10,4 +10,29 @@ These are nothing more than text files with RGB hex values, making
 it quite easy to include more palettes to the default library in the future.
 """
 
+from importlib import resources
+from pathlib import Path
+from typing import List
+
+import numpy as np
+import numpy.typing as npt
+
+from pylettize.pylettize import hex_to_rgb
+
 OPTIONS = ["gruvbox", "obama", "primaries"]
+
+
+def get_default_palette(palette_name: str) -> List[npt.NDArray[np.float32]]:
+    """Retrieve one of the default palettes."""
+    assert (
+        palette_name in OPTIONS
+    ), f"'{palette_name}' not in the default palettes {OPTIONS}"
+    palette_file = resources.open_text("pylettize.palettes", palette_name)
+    with palette_file as file:
+        return list(map(hex_to_rgb, file))
+
+
+def get_palette_from_file(palette_file: Path) -> List[npt.NDArray[np.float32]]:
+    """Parse and return the palette from a supplied text file."""
+    with open(palette_file, "rt") as file:
+        return list(map(hex_to_rgb, file))

--- a/pylettize/pylettize.py
+++ b/pylettize/pylettize.py
@@ -3,6 +3,8 @@ Pylettize/Core.
 
 This module contains the core functionality for pylettize to function.
 """
+from typing import List
+
 import numpy as np
 import numpy.typing as npt
 
@@ -18,21 +20,43 @@ def hex_to_rgb(hex_str: str) -> npt.NDArray[np.float32]:
 def dist_to_color(
     im: npt.NDArray[np.float32], color: npt.NDArray[np.float32]
 ) -> npt.NDArray[np.float32]:
-    """Compute the distance map for a full color image to a given color value."""
+    """Compute a normalized distance map for an image to a given color value."""
     dist: npt.NDArray[np.float32] = np.linalg.norm(im - color, axis=2)
     return dist / (EPSILON + np.max(dist))
 
 
+def similarity_map(
+    im: npt.NDArray[np.float32], palette: List[npt.NDArray[np.float32]]
+) -> npt.NDArray[np.float32]:
+    """Compute a map of similarity values between an image and palette."""
+    distance_map = np.stack([dist_to_color(im, color) for color in palette])
+    return 1.0 - distance_map
+
+
+def weight_map(
+    im: npt.NDArray[np.float32],
+    palette: List[npt.NDArray[np.float32]],
+    temperature: float,
+) -> npt.NDArray[np.float32]:
+    """Compute temperature scaled softmax weights betwen an image and palette."""
+    sim_map = similarity_map(im, palette)
+    weight_map = np.exp(sim_map / temperature)
+    weight_map /= np.sum(weight_map, axis=0)
+    return weight_map
+
+
 def hard_blending(
-    dist_map: npt.NDArray[np.float32], palette: npt.NDArray[np.float32]
+    dist_map: npt.NDArray[np.float32], palette: List[npt.NDArray[np.float32]]
 ) -> npt.NDArray[np.float32]:
     """Blend with the palette using hard lookup."""
-    lookup: npt.NDArray[np.uint] = np.argmin(dist_map, axis=0)
-    return palette[lookup]
+    palette_array = np.array(palette)
+    lookup: npt.NDArray[np.uint] = np.argmax(dist_map, axis=0)
+    return palette_array[lookup]
 
 
 def linear_blending(
-    weight_map: npt.NDArray[np.float32], palette: npt.NDArray[np.float32]
+    weights: npt.NDArray[np.float32], palette: List[npt.NDArray[np.float32]]
 ) -> npt.NDArray[np.float32]:
     """Blend with the palette using soft linear blending."""
-    return np.transpose(weight_map, axes=[1, 2, 0]) @ palette
+    palette_array = np.array(palette)
+    return np.transpose(weights, axes=[1, 2, 0]) @ palette_array

--- a/pylettize/pylettize.py
+++ b/pylettize/pylettize.py
@@ -24,11 +24,11 @@ def dist_to_color(
 
 
 def hard_blending(
-    weight_map: npt.NDArray[np.float32], palette: npt.NDArray[np.float32]
+    dist_map: npt.NDArray[np.float32], palette: npt.NDArray[np.float32]
 ) -> npt.NDArray[np.float32]:
     """Blend with the palette using hard lookup."""
-    lookup: npt.NDArray[np.uint] = np.argmax(weight_map, axis=0)
-    return np.take(np.array(palette), lookup)
+    lookup: npt.NDArray[np.uint] = np.argmin(dist_map, axis=0)
+    return palette[lookup]
 
 
 def linear_blending(

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ include_package_data = True
 
 [options.entry_points]
 console_scripts = 
-    pylettize = pylettize.cli:_console_entry_point
+    pylettize = pylettize.cli:run
 
 [flake8]
 # Conform with the black line length

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,10 @@ python_requires = >=3.8
 zip_safe = False
 include_package_data = True
 
+[options.entry_points]
+console_scripts = 
+    pylettize = pylettize.cli:_console_entry_point
+
 [flake8]
 # Conform with the black line length
 max_line_length=88 
@@ -84,3 +88,7 @@ python_files=*.py
 
 # Any function in the test file is a test
 python_functions=test_*
+
+[tool:isort]
+# Ensure isort is black compatible
+profile = black


### PR DESCRIPTION
With this PR, users should be able to actually use `pylettize` as a command line utility. This means the functionality to actually run the script has been moved from the `pylettize.pylettize` module to the new `pylettize.cli` module.

There seems a bug may have been introduced with the hard blending mode though, as this now only produces grayscale images.

Closes #1 